### PR TITLE
Fix: Add the list of protected fields to the Request model

### DIFF
--- a/addons/bestja_requests/models.py
+++ b/addons/bestja_requests/models.py
@@ -116,6 +116,7 @@ class Request(models.Model):
         ('accepted', 'zaakceptowane'),
         ('rejected', 'odrzucone'),
     ]
+    _protected_fields = ['state']
 
     state = fields.Selection(STATES, default='draft', string="Stan")
     name = fields.Char(


### PR DESCRIPTION
There is no point in using `protected_fields` mixin, without actually
specifying a list of fields that should be protected.