### PR TITLE
Changed all occurrences of self.env.user.id to self.env.uid

### DIFF
--- a/addons/bestja_detailed_reports/models.py
+++ b/addons/bestja_detailed_reports/models.py
@@ -90,8 +90,8 @@ class DetailedReport(models.Model):
             ('use_detailed_reports', '=', True),
             ('detailed_reports', '=', False),
             '|',  # noqa
-                ('manager', '=', self.env.user.id),
-                ('organization.coordinator', '=', self.env.user.id),
+                ('manager', '=', self.env.uid),
+                ('organization.coordinator', '=', self.env.uid),
         ],
         ondelete='restrict',
     )
@@ -150,14 +150,14 @@ class DetailedReport(models.Model):
         """
         Is current user authorized to moderate (accept/reject) the detailed_report?
         """
-        uid = self.env.user.id
+        uid = self.env.uid
         project = self.sudo().project
         moderate_own = project.organization.level == 1 and \
             (project.manager.id == uid or project.organization.coordinator.id == uid)
 
         self.user_can_moderate = (
-            moderate_own or project.parent.manager.id == self.env.user.id or
-            project.parent.organization.coordinator.id == self.env.user.id
+            moderate_own or project.parent.manager.id == self.env.uid or
+            project.parent.organization.coordinator.id == self.env.uid
         )
 
     @api.one

--- a/addons/bestja_offers/models/offer.py
+++ b/addons/bestja_offers/models/offer.py
@@ -59,7 +59,7 @@ class Offer(models.Model):
         domain=lambda self: [
             '|',
             ('organization.id', '=', self.env.user.coordinated_org.id),
-            ('manager.id', '=', self.env.user.id),
+            ('manager.id', '=', self.env.uid),
         ]
     )
     organization = fields.Many2one(

--- a/addons/bestja_offers_moderation/models.py
+++ b/addons/bestja_offers_moderation/models.py
@@ -50,7 +50,7 @@ class OfferWithModeration(models.Model):
         provided current user is not the admin or an offer moderator.
         """
         if self.state == 'published' \
-                and self.env.user.id != SUPERUSER_ID \
+                and self.env.uid != SUPERUSER_ID \
                 and not self.is_moderator():
             self.set_pending()
 

--- a/addons/bestja_organization/models.py
+++ b/addons/bestja_organization/models.py
@@ -207,7 +207,7 @@ class Organization(models.Model):
         return [
             ('state', '=', 'pending'),
             ('active', '=?', False),
-            ('coordinator', '!=', self.env.user.id),
+            ('coordinator', '!=', self.env.uid),
         ]
 
 

--- a/addons/bestja_organization_hierarchy/models.py
+++ b/addons/bestja_organization_hierarchy/models.py
@@ -54,7 +54,7 @@ class Organization(models.Model):
         """
         Only super admin is able to add primary (parentless) organizations.
         """
-        if self.env.user.id == SUPERUSER_ID:
+        if self.env.uid == SUPERUSER_ID:
             return
         if not self.parent:
             raise exceptions.ValidationError("Wybierz organizację nadrzędną!")

--- a/addons/bestja_project/models.py
+++ b/addons/bestja_project/models.py
@@ -27,7 +27,7 @@ class Project(models.Model):
         default=lambda self: self.env.user.coordinated_org,
         required=True,
         string="Organizacja",
-        domain=lambda self: [('coordinator', '=', self.env.user.id)],
+        domain=lambda self: [('coordinator', '=', self.env.uid)],
     )
     manager = fields.Many2one(
         'res.users',
@@ -166,7 +166,7 @@ class Task(models.Model):
         Checks if current user == user responsible for task,
         for hiding and unhiding button "rozpocznij"
         """
-        self.user_assigned_task = (self.env.user.id == self.user.id)
+        self.user_assigned_task = (self.env.uid == self.user.id)
 
     @api.one
     def set_in_progress(self):

--- a/addons/bestja_requests/models.py
+++ b/addons/bestja_requests/models.py
@@ -178,8 +178,8 @@ class Request(models.Model):
         Is current user authorized to moderate (accept/reject) the request?
         """
         self.user_can_moderate = (
-            self.parent_project.manager.id == self.env.user.id or
-            self.parent_project.organization.coordinator.id == self.env.user.id
+            self.parent_project.manager.id == self.env.uid or
+            self.parent_project.organization.coordinator.id == self.env.uid
         )
 
     @api.multi

--- a/addons/bestja_volunteer/models.py
+++ b/addons/bestja_volunteer/models.py
@@ -224,7 +224,7 @@ class Volunteer(models.Model):
         Hide values for fields current user doesn't have access to.
         """
         results = super(Volunteer, self).read(fields=fields, load=load)
-        if self.env.user.id == SUPERUSER_ID:
+        if self.env.uid == SUPERUSER_ID:
             return results
 
         for record, fields_dict in izip(self, results):
@@ -265,9 +265,9 @@ class Volunteer(models.Model):
         Access level that the current (logged in) user has for the object.
         Either "owner", "admin", "privileged" or None.
         """
-        if self.id == self.env.user.id:
+        if self.id == self.env.uid:
             self.user_access_level = 'owner'
-        elif self.env.user.id == SUPERUSER_ID or self.user_has_groups('bestja_base.instance_admin'):
+        elif self.env.uid == SUPERUSER_ID or self.user_has_groups('bestja_base.instance_admin'):
             self.user_access_level = 'admin'
         else:
             self.user_access_level = None
@@ -478,4 +478,4 @@ class Partner(models.Model):
         super(Partner, self).check_access_rule(operation)
         related_users = self.sudo().user_ids
         if related_users:
-            related_users.sudo(self.env.user.id).check_access_rule(operation)
+            related_users.sudo(self.env.uid).check_access_rule(operation)

--- a/addons/protected_fields/models.py
+++ b/addons/protected_fields/models.py
@@ -27,7 +27,7 @@ class ProtectedFieldsMixin(models.AbstractModel):
         For more advanced rules, you can modify this method in your model.
         """
         # User permissions
-        if self.env.user.id in self._permitted_user_ids:
+        if self.env.uid in self._permitted_user_ids:
             return True
 
         # Group permissions


### PR DESCRIPTION
The former requires additional db query to retrive the user object from the database,
while the latter is already present in the environment and ready to be used.