### PR TITLE
Make a whole bunch of methods private

### DIFF
--- a/addons/bestja_base/demo.xml
+++ b/addons/bestja_base/demo.xml
@@ -4,6 +4,6 @@
         <!-- Force Polish as the default language for the default website.
         This is a bit hackish, but we need this for our demo instances.
         Sorry. -->
-        <function model="website" name="set_language" eval="[ref('website.default_website'), 'pl_PL']"/>
+        <function model="website" name="_set_language" eval="[ref('website.default_website'), 'pl_PL']"/>
     </data>
 </openerp>

--- a/addons/bestja_base/models.py
+++ b/addons/bestja_base/models.py
@@ -30,7 +30,7 @@ class Website(models.Model):
     _inherit = 'website'
 
     @api.one
-    def set_language(self, lang_code):
+    def _set_language(self, lang_code):
         """
         Set language for a website.
         If the language is not already loaded

--- a/addons/bestja_detailed_reports/models.py
+++ b/addons/bestja_detailed_reports/models.py
@@ -9,21 +9,21 @@ class Project(models.Model):
     detailed_reports = fields.One2many('bestja.detailed_report', inverse_name='project')
     enable_detailed_reports = fields.Boolean(string="Raporty szczegółowe do zbiórki żywności")
     use_detailed_reports = fields.Boolean(
-        compute='compute_use_detailed_reports',
+        compute='_compute_use_detailed_reports',
         compute_sudo=True,
-        search='search_use_detailed_reports',
+        search='_search_use_detailed_reports',
     )
 
     @api.one
     @api.depends('enable_detailed_reports', 'parent.enable_detailed_reports', 'parent.parent.enable_detailed_reports')
-    def compute_use_detailed_reports(self):
+    def _compute_use_detailed_reports(self):
         self.use_detailed_reports = (
             self.enable_detailed_reports or
             self.parent.enable_detailed_reports or
             self.parent.parent.enable_detailed_reports
         )
 
-    def search_use_detailed_reports(self, operator, value):
+    def _search_use_detailed_reports(self, operator, value):
         return [
             '|',  # noqa
                 ('enable_detailed_reports', operator, value),
@@ -101,10 +101,10 @@ class DetailedReport(models.Model):
         related='project.organization',
     )
     name = fields.Char(string="Nazwa projektu", related="project.name")
-    dates = fields.Char(string="Termin", compute="compute_project_dates", store=True)
+    dates = fields.Char(string="Termin", compute="_compute_project_dates", store=True)
     state = fields.Selection(STATES, default='draft', string="Status:")
     report_entries = fields.One2many('bestja.report_entry', inverse_name='detailed_report', string="Produkt")
-    tonnage = fields.Float(string="Tonaż (kg)", compute="compute_report_tonnage", store=True)
+    tonnage = fields.Float(string="Tonaż (kg)", compute="_compute_report_tonnage", store=True)
     parent_project = fields.Many2one(
         'bestja.project',
         string="Projekt nadrzędny",
@@ -114,15 +114,15 @@ class DetailedReport(models.Model):
     responsible_organization = fields.Many2one(
         'organization',
         string="Zainteresowane organizacje",
-        compute="compute_responsible_organization",
+        compute="_compute_responsible_organization",
         compute_sudo=True,
         store=True,
     )
-    user_can_moderate = fields.Boolean(compute="compute_user_can_moderate")
+    user_can_moderate = fields.Boolean(compute="_compute_user_can_moderate")
 
     @api.one
     @api.depends('parent_project', 'project')
-    def compute_responsible_organization(self):
+    def _compute_responsible_organization(self):
         """
         The organizations on the middle level (1) are responsible for managing
         their reports and reports of their children.
@@ -138,7 +138,7 @@ class DetailedReport(models.Model):
 
     @api.one
     @api.depends('report_entries')
-    def compute_report_tonnage(self):
+    def _compute_report_tonnage(self):
         """
         For showing the sum of kg of products
         """
@@ -146,7 +146,7 @@ class DetailedReport(models.Model):
 
     @api.one
     @api.depends('parent_project')
-    def compute_user_can_moderate(self):
+    def _compute_user_can_moderate(self):
         """
         Is current user authorized to moderate (accept/reject) the detailed_report?
         """
@@ -162,7 +162,7 @@ class DetailedReport(models.Model):
 
     @api.one
     @api.depends('project')
-    def compute_project_dates(self):
+    def _compute_project_dates(self):
         """
         For nice format in the list of all projects.
         """

--- a/addons/bestja_offers/messages.xml
+++ b/addons/bestja_offers/messages.xml
@@ -33,8 +33,8 @@
                 Zgłosiłeś się na ofertę "${record.offer.name}". Chcielibyśmy Cię lepiej poznać.
 
                 <ul>
-                    <li><a target="_blank" href="${base_url}${record.get_meeting_confirmation_link('accepted')}">Potwierdź termin spotkania</a></li>
-                    <li><a target="_blank" href="${base_url}${record.get_meeting_confirmation_link('rejected')}">Odrzuć termin spotkania</a></li>
+                    <li><a target="_blank" href="${base_url}${record._get_meeting_confirmation_link('accepted')}">Potwierdź termin spotkania</a></li>
+                    <li><a target="_blank" href="${base_url}${record._get_meeting_confirmation_link('rejected')}">Odrzuć termin spotkania</a></li>
                 </ul>
             ]]></field>
             <field name="model">offers.application</field>

--- a/addons/bestja_offers_by_org/models.py
+++ b/addons/bestja_offers_by_org/models.py
@@ -7,9 +7,9 @@ from openerp.addons.website.models.website import slugify
 class Offer(models.Model):
     _inherit = 'organization'
 
-    city_slug = fields.Char(compute='compute_city_slug', store=True, index=True)
+    city_slug = fields.Char(compute='_compute_city_slug', store=True, index=True)
 
     @api.one
     @api.depends('city')
-    def compute_city_slug(self):
+    def _compute_city_slug(self):
         self.city_slug = slugify(self.city)

--- a/addons/bestja_offers_moderation/models.py
+++ b/addons/bestja_offers_moderation/models.py
@@ -14,7 +14,7 @@ class OfferWithModeration(models.Model):
 
     state = fields.Selection(selection_add=[('pending', "oczekująca na akceptację")])
 
-    def is_moderator(self):
+    def _is_moderator(self):
         """
         Returns a boolean value indicating whether current user
         is an offer moderator.
@@ -31,7 +31,7 @@ class OfferWithModeration(models.Model):
 
     @api.one
     def set_published(self):
-        if self.is_moderator():
+        if self._is_moderator():
             previous_state = self.state
             self.state = 'published'
             if previous_state == 'pending':
@@ -51,7 +51,7 @@ class OfferWithModeration(models.Model):
         """
         if self.state == 'published' \
                 and self.env.uid != SUPERUSER_ID \
-                and not self.is_moderator():
+                and not self._is_moderator():
             self.set_pending()
 
     @api.model
@@ -77,7 +77,7 @@ class OfferWithModeration(models.Model):
 
         doc = etree.XML(view['arch'])
 
-        if self.is_moderator():
+        if self._is_moderator():
             button_pending = doc.xpath("//button[@name='set_pending']")
             if button_pending:
                 button_pending[0].getparent().remove(button_pending[0])
@@ -90,6 +90,6 @@ class OfferWithModeration(models.Model):
         """
         Show pending offers count in menu - only for moderators.
         """
-        if not self.is_moderator():
+        if not self._is_moderator():
             return False
         return [('state', '=', 'pending')]

--- a/addons/bestja_offers_search/config.py
+++ b/addons/bestja_offers_search/config.py
@@ -15,4 +15,4 @@ class BestJaSettings(models.TransientModel):
         """
         index = OffersIndex(dbname=self.env.cr.dbname)
         index.create_index()
-        self.env['offer'].search([('state', '=', 'published')]).whoosh_reindex()
+        self.env['offer'].search([('state', '=', 'published')])._whoosh_reindex()

--- a/addons/bestja_offers_search/models.py
+++ b/addons/bestja_offers_search/models.py
@@ -13,10 +13,10 @@ class Offer(models.Model):
         ids = self.pool['offer'].search(
             cr, SUPERUSER_ID, [('state', '=', 'published')],
         )
-        self.pool['offer'].whoosh_reindex(cr, SUPERUSER_ID, ids)
+        self.pool['offer']._whoosh_reindex(cr, SUPERUSER_ID, ids)
 
     @api.multi
-    def whoosh_reindex(self):
+    def _whoosh_reindex(self):
         """
         Update/Add offers to the whoosh index.
         """
@@ -46,13 +46,13 @@ class Offer(models.Model):
     @api.model
     def create(self, vals):
         record = super(Offer, self).create(vals)
-        record.whoosh_reindex()
+        record._whoosh_reindex()
         return record
 
     @api.multi
     def write(self, vals):
         val = super(Offer, self).write(vals)
-        self.whoosh_reindex()
+        self._whoosh_reindex()
         return val
 
     @api.multi

--- a/addons/bestja_project_hierarchy/models.py
+++ b/addons/bestja_project_hierarchy/models.py
@@ -31,7 +31,7 @@ class ProjectInvitation(models.Model):
         STATES,
         default='pending',
         store=True,
-        compute='compute_state',
+        compute='_compute_state',
         compute_sudo=True,
         string="Stan",
     )
@@ -39,7 +39,7 @@ class ProjectInvitation(models.Model):
     accepted_time = fields.Datetime(
         string="Data zaakceptowania",
         store=True,
-        compute='compute_accepted_time',
+        compute='_compute_accepted_time',
         compute_sudo=True,
     )
     invited_projects = fields.One2many('bestja.project', inverse_name='parent_invitation')
@@ -54,7 +54,7 @@ class ProjectInvitation(models.Model):
 
     @api.one
     @api.constrains('organization')
-    def check_organization_child(self):
+    def _check_organization_child(self):
         is_child = self.env['organization'].search_count([
             ('id', '=', self.organization.id),
             ('parent', '=', self.project.organization.id),
@@ -66,12 +66,12 @@ class ProjectInvitation(models.Model):
 
     @api.one
     @api.depends('invited_projects')
-    def compute_state(self):
+    def _compute_state(self):
         self.state = 'accepted' if self.invited_projects else 'pending'
 
     @api.one
     @api.depends('invited_projects')
-    def compute_accepted_time(self):
+    def _compute_accepted_time(self):
         invited_projects = self.invited_projects.sorted(key=lambda r: r.create_date)
         if invited_projects:
             self.accepted_time = invited_projects[0].create_date
@@ -142,7 +142,7 @@ class Project(models.Model):
     parent_invitation = fields.Many2one(
         'bestja.project.invitation',
         store=True,
-        compute='compute_parent_invitation',
+        compute='_compute_parent_invitation',
         compute_sudo=True,
     )
     organization_level = fields.Integer(
@@ -151,7 +151,7 @@ class Project(models.Model):
 
     @api.one
     @api.depends('organization', 'parent')
-    def compute_parent_invitation(self):
+    def _compute_parent_invitation(self):
         """
         Find invitation that was used to create this project.
         """

--- a/addons/bestja_project_hierarchy/wizards.py
+++ b/addons/bestja_project_hierarchy/wizards.py
@@ -5,7 +5,7 @@ from openerp import models, fields, api
 class InvitationWizard(models.TransientModel):
     _name = 'bestja.project.invitation_wizard'
 
-    def available_organizations(self):
+    def _available_organizations(self):
         project_id = self.env.context.get('active_id')
         domain = []
         if project_id:
@@ -19,11 +19,11 @@ class InvitationWizard(models.TransientModel):
         return domain
 
     @api.model
-    def default_organizations(self):
+    def _default_organizations(self):
         """
         All organizations chosen by default.
         """
-        domain = self.available_organizations()
+        domain = self._available_organizations()
         return self.env['organization'].search(domain)
 
     project = fields.Many2one(
@@ -33,8 +33,8 @@ class InvitationWizard(models.TransientModel):
     )
     organizations = fields.Many2many(
         'organization',
-        domain=available_organizations,
-        default=default_organizations,
+        domain=_available_organizations,
+        default=_default_organizations,
         string="Organizacje",
     )
     description = fields.Text(string="Opis")

--- a/addons/bestja_requests/models.py
+++ b/addons/bestja_requests/models.py
@@ -216,11 +216,11 @@ class Request(models.Model):
         related='project.parent',
         store=True,
     )
-    user_can_moderate = fields.Boolean(compute="compute_user_can_moderate")
+    user_can_moderate = fields.Boolean(compute="_compute_user_can_moderate")
 
     @api.one
     @api.depends('parent_project')
-    def compute_user_can_moderate(self):
+    def _compute_user_can_moderate(self):
         """
         Is current user authorized to moderate (accept/reject) the request?
         """

--- a/addons/bestja_ucw_permissions/models.py
+++ b/addons/bestja_ucw_permissions/models.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from openerp import models, fields, api
+from openerp import models
+
 
 class Volunteer(models.Model):
     _name = 'res.users'
@@ -11,9 +12,9 @@ class Volunteer(models.Model):
 
     def __init__(self, pool, cr):
         super(Volunteer, self).__init__(pool, cr)
-        self.remove_permitted_fields(level='privileged', fields={'email', 'phone', 'birthdate', 'place_of_birth',
+        self._remove_permitted_fields(level='privileged', fields={
+            'email', 'phone', 'birthdate', 'place_of_birth',
             'citizenship', 'street_gov', 'street_number_gov', 'apt_number_gov', 'zip_code_gov', 'city_gov',
             'voivodeship_gov', 'country_gov', 'different_addresses', 'street', 'street_number', 'apt_number',
             'zip_code', 'city', 'voivodeship', 'country', 'pesel', 'document_id_kind', 'document_id'
         })
-

--- a/addons/bestja_volunteer/demo.xml
+++ b/addons/bestja_volunteer/demo.xml
@@ -4,7 +4,7 @@
         <!-- Force Polish as the default language for all new users.
         This is a bit hackish, but we need this for our demo instances.
         Sorry. -->
-        <function model="res.users" name="set_default_language" eval="['pl_PL']"/>
+        <function model="res.users" name="_set_default_language" eval="['pl_PL']"/>
 
         <!-- Users -->
         <record id="user_administrator" model="res.users">

--- a/addons/bestja_volunteer_notes/models.py
+++ b/addons/bestja_volunteer_notes/models.py
@@ -14,30 +14,30 @@ class VolunteerWithNotes(models.Model):
 
     def __init__(self, pool, cr):
         super(VolunteerWithNotes, self).__init__(pool, cr)
-        self.add_permitted_fields(level='privileged', fields={'notes'})
+        self._add_permitted_fields(level='privileged', fields={'notes'})
 
 
 class VolunteerNote(models.Model):
     _name = 'bestja.volunteer_note'
 
     @api.model
-    def default_user(self):
+    def _default_user(self):
         return self.env.context.get('active_id')
 
     @api.model
-    def default_organization(self):
+    def _default_organization(self):
         return self.env.user.coordinated_org.id
 
     body = fields.Text(required=True, string="Treść")
     user = fields.Many2one(
         'res.users',
         required=True,
-        default=default_user,
+        default=_default_user,
         string="Wolontariusz",
     )
     organization = fields.Many2one(
         'organization',
-        default=default_organization,
+        default=_default_organization,
     )
 
     @api.one

--- a/addons/email_confirmation/controllers.py
+++ b/addons/email_confirmation/controllers.py
@@ -19,7 +19,7 @@ class AuthSignupHome(AuthSignupHome):
         else:
             try:
                 values = dict((key, qcontext.get(key)) for key in ('login', 'email'))
-                request.env['res.users'].sudo().authenticate_after_confirmation(values, qcontext.get('token'))
+                request.env['res.users'].sudo()._authenticate_after_confirmation(values, qcontext.get('token'))
                 request.cr.commit()
 
                 response = super(AuthSignupHome, self).web_login(*args, **kw)

--- a/addons/email_confirmation/models.py
+++ b/addons/email_confirmation/models.py
@@ -45,7 +45,7 @@ class Users(models.Model):
     active_state = fields.Selection(STATES, default='active', store=True, string="Stan")
 
     @api.model
-    def authenticate_after_confirmation(self, values, token=None):
+    def _authenticate_after_confirmation(self, values, token=None):
         if token:
             # signup with a token: find the corresponding partner id
             partner = self.env['res.partner']._signup_retrieve_partner(


### PR DESCRIPTION
I just found out why so many methods in Odoo models starts with underscore.
I thought it was just a matter of style. Nope. Methods starting with
underscore are not exposed via the public XML-RPC API.
I went back and changed names of a bunch of our methods that doesn't
need to be accessible via the RPC API.