### PR TITLE
New offers list by organization plus some fixes

### DIFF
--- a/addons/bestja_frontend_fpbz/static/src/css/custom.css
+++ b/addons/bestja_frontend_fpbz/static/src/css/custom.css
@@ -5,6 +5,7 @@
 #wrap, section{
     font-family: 'Open Sans', sans-serif;
     font-size: 20px;
+    overflow-x: hidden;
 }
 
 .open_sans_bold{
@@ -22,6 +23,16 @@ section .container-fluid{
         margin-left: 0;
         margin-right: 0;
     }
+}
+
+a{
+    color: #F29000;
+    text-decoration: none;
+}
+
+a:focus, a:hover{
+    color: #F9A426;
+    text-decoration: none;
 }
 
 h1, .h1{
@@ -438,9 +449,12 @@ text:hover{
 
 /* Snippet: volunteeres pictures */
 .slider_container{
-    width: 1920px;
+    width: 1890px;
     margin-left: auto;
     margin-right: auto;
+    overflow: hidden;
+    padding-left: 15px;
+    padding-right: 15px;
 }
 
 .carousel_column{
@@ -451,7 +465,7 @@ text:hover{
 
 @media screen and (max-width: 1920px) {
     .slider_container{
-        width: 1170px;
+        width: 1140px;
     }
 
     .carousel_column{
@@ -475,7 +489,7 @@ text:hover{
     }
 
     .carousel_column{
-        width: calc(737px / 2 - 30px);
+        width: calc(737px / 3 - 30px);
     }
 }
 
@@ -485,7 +499,7 @@ text:hover{
     }
 
     .carousel_column{
-        width: 450px;
+        width: calc(450px / 3 - 30px);
     }
 }
 
@@ -495,7 +509,7 @@ text:hover{
     }
 
     .carousel_column{
-        width: 290px;
+        width: calc(290px / 3 - 30px);
     }
 }
 
@@ -570,7 +584,6 @@ text:hover{
 /* Offers snippet */
 .date_of_the_offer, .content_of_the_offer{
     background-color: #F0F0F0;
-    height: 175px;
 }
 
 .offer_where{
@@ -585,20 +598,11 @@ text:hover{
 .offers_the_day{
     font-size: 40px;
     color: #3C4049;
-    margin-top: calc(23% - 40px);
-    margin-bottom: calc(23% - 40px);
 }
 
 .offers_the_month{
     font-size: 16px;
     color: #3C4049;
-    margin-top: calc(23% - 16px);
-    margin-bottom: calc(23% - 16px);
-}
-
-.date_of_the_offer p{
-    margin-top: calc(15% - 26px);
-    margin-bottom: calc(15% - 26px);
 }
 
 .title_of_the_offer a{
@@ -645,13 +649,13 @@ text:hover{
 }
 
 .offer_place:before{
-    background: #F9A426 url('/bestja_frontend_fpbz/static/src/img/content/miejsce-01.svg');
+    background: url('/bestja_frontend_fpbz/static/src/img/content/miejsce-01.svg');
     background-size: 20px 20px;
     background-repeat: no-repeat;
 }
 
 .offer_how_long:before{
-    background: #F9A426 url('/bestja_frontend_fpbz/static/src/img/content/czas-01.svg');
+    background: url('/bestja_frontend_fpbz/static/src/img/content/czas-01.svg');
     background-size: 20px 20px;
     background-repeat: no-repeat;
 
@@ -944,3 +948,14 @@ text:hover{
     color: #3c4049;
 }
 /* End of Slick Slider */
+
+/* Custom settings for offers pages */
+.print_icon:hover{
+    background-image: url('/bestja_frontend_fpbz/static/src/img/content/printer_hover.svg');
+}
+
+.btn_join:hover{
+    background-color: #F9A426;
+}
+
+/* End of custom settings for offers pages */

--- a/addons/bestja_frontend_fpbz/static/src/css/footer.css
+++ b/addons/bestja_frontend_fpbz/static/src/css/footer.css
@@ -1,16 +1,4 @@
 /* Footer */
-footer .container-fluid{
-    padding-left: 80px;
-    padding-right: 80px;
-}
-
-@media screen and (max-width: 991px) {
-    footer .container-fluid{
-        padding-left: 0;
-        padding-right: 0;
-    }
-}
-
 .footer_logo_container{
     text-align: left;
 }
@@ -35,22 +23,17 @@ footer .container-fluid{
     background-repeat: no-repeat;
     width: 250px;
     height: 80px;
-    margin-left: 20px;
-}
-
-@media screen and (max-width: 991px) {
-    .footer_logo{
-        margin-left: 10px;
-    }
 }
 
 .footer_icons_container{
     text-align: right;
+    padding-right: 0;
 }
 
 @media screen and (max-width: 991px) {
     .footer_icons_container{
         text-align: center;
+        padding-right: 15px;
     }
 }
 
@@ -63,10 +46,18 @@ footer .container-fluid{
     margin-bottom: 20px;
 }
 
+.footer_icons li:last-child{
+    margin-right: 0;
+}
+
 @media screen and (max-width: 991px) {
     .footer_icons li{
         text-align: center;
         float: none;
+    }
+
+    .footer_icons li:last-child{
+        margin-right: 20px;
     }
 }
 
@@ -99,9 +90,10 @@ footer .container-fluid{
 }
 
 .footer_div{
-    background-color: #F39100;
     min-height: 100px;
     padding-top: 25px;
+    width: 100%;
+    background-color: #F39100;
 }
 
 .footer_div a{
@@ -149,6 +141,10 @@ footer .container-fluid{
     color: #FFFFFF;
     font-size: 14px;
     margin-left: 10px;
+}
+
+.footer_contact li:first-child, .footer_contact li a:first-child{
+        margin-left: 0;
 }
 
 @media screen and (max-width: 991px) {

--- a/addons/bestja_frontend_fpbz/static/src/img/content/printer_hover.svg
+++ b/addons/bestja_frontend_fpbz/static/src/img/content/printer_hover.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="512px" height="512px" viewBox="0 0 512 512" enable-background="new 0 0 512 512" xml:space="preserve">
+<g>
+	<path fill="#F9A426" d="M128,32h256v64h32V32c0-17.656-14.313-32-32-32H128c-17.656,0-32,14.344-32,32v64h32V32z"/>
+	<path fill="#F9A426" d="M480,128H32c-17.656,0-32,14.344-32,32v160c0,17.688,14.344,32,32,32h64v128c0,17.688,14.344,32,32,32h256
+		c17.688,0,32-14.313,32-32V352h64c17.688,0,32-14.313,32-32V160C512,142.344,497.688,128,480,128z M384,480H128V256h256V480z
+		 M448,224c-17.688,0-32-14.313-32-32c0-17.656,14.313-32,32-32s32,14.344,32,32C480,209.688,465.688,224,448,224z"/>
+	<rect fill="#F9A426" x="160" y="288" width="128" height="32"/>
+	<rect fill="#F9A426" x="160" y="352" width="192" height="32"/>
+	<rect fill="#F9A426" x="160" y="416" width="192" height="32"/>
+</g>
+</svg>

--- a/addons/bestja_frontend_fpbz/static/src/js/custom.js
+++ b/addons/bestja_frontend_fpbz/static/src/js/custom.js
@@ -209,32 +209,62 @@ jQuery(window).ready(function () {
         speed: 300,
         slidesToShow: 1,
         centerMode: true,
-        variableWidth: true
+        variableWidth: true,
+        responsive: [
+            {
+                breakpoint: 767,
+                settings: {
+                    variableWidth: false
+                }
+            }
+        ]
     });
     $('.volunteers_bulletin_slider').slick({
         infinite: true,
         speed: 300,
         slidesToShow: 2,
         centerMode: true,
-        variableWidth: true
+        variableWidth: true,
+        responsive: [
+            {
+                breakpoint: 767,
+                settings: {
+                    variableWidth: false
+                }
+            }
+        ]
     });
     $('.the_tasks_of_volunteer_slider').slick({
         infinite: true,
         speed: 300,
         slidesToShow: 1,
         centerMode: true,
-        variableWidth: true
+        variableWidth: true,
+        responsive: [
+            {
+                breakpoint: 767,
+                settings: {
+                    variableWidth: false
+                }
+            }
+        ]
     });
     $('.the_tasks_of_coordinator_slider').slick({
         infinite: true,
         speed: 300,
         slidesToShow: 1,
         centerMode: true,
-        variableWidth: true
+        variableWidth: true,
+        responsive: [
+            {
+                breakpoint: 767,
+                settings: {
+                    variableWidth: false
+                }
+            }
+        ]
     });
 
-    $('.slick-prev').html('Poprzedni');
-    $('.slick-next').html('Następny');
     /* End of photo slider */
 
 });

--- a/addons/bestja_offers/models/offer.py
+++ b/addons/bestja_offers/models/offer.py
@@ -67,7 +67,7 @@ class Offer(models.Model):
         string="Organizacja",
         related='project.organization'
     )
-    organization_image = fields.Binary(related='organization.image_medium')
+    organization_image = fields.Binary(related='organization.image')
     skills = fields.Many2many('volunteer.skill', required=True)
     wishes = fields.Many2many('volunteer.wish', required=True)
     drivers_license = fields.Many2one('volunteer.drivers_license', string="Prawa jazdy")

--- a/addons/bestja_offers/static/src/css/offers_frontend.css
+++ b/addons/bestja_offers/static/src/css/offers_frontend.css
@@ -105,7 +105,7 @@
     font-weight: bold;
 }
 
-.empty_category_title{
+.empty_category_title, .empty_offer_title{
     font-size: 24px;
     font-weight: 300;
 }

--- a/addons/bestja_offers_by_org/templates.xml
+++ b/addons/bestja_offers_by_org/templates.xml
@@ -1,15 +1,101 @@
 <openerp>
     <data>
         <template id="list">
-            <t t-call="website.layout" name="Oferty">
-                <h1><t t-esc="organization.display_name"/> (<t t-esc="organization.city"/>)</h1>
-                <ul>
-                    <li t-foreach="offers" t-as="offer">
-                        <a t-attf-href="{{ offer.get_public_url() }}">
-                            <t t-esc="offer.display_name"/>
-                        </a>
-                    </li>
-                </ul>
+            <t t-call="website.layout">
+                <div id="wrap" class="oe_structure oe_empty">
+                    <section class="oe_snippet_body">
+                        <div class="container-fluid">
+                            <div class="row">
+                                <div class="col-md-12">
+                                    <h1 class="text-center mt48 mb48 section_title" t-if="offers">Oferty wolontariatu: <t t-esc="organization.city"/></h1>
+                                    <h2 class="text-center mt48 mb48 section_title" t-if="not offers">Brak dostępnych ofert</h2>
+                                    <h2 class="text-center mt48 mb48 empty_offer_title" t-if="not offers">
+                                        <a href="/#choose_place_title">Zobacz oferty z innych miast</a>
+                                    </h2>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+                    <t t-foreach="offers" t-as="offer">
+                        <section class="oe_sinppet_body container">
+                            <div class="row animation_row">
+                                <div class="col-xs-2 col-md-2 hidden-xs hidden-sm">
+                                    <div class="tile first">
+                                        <div class="tile-content">
+                                            <div class="one">
+                                                <div class="well text-center date_of_the_offer">
+                                                    <p class="offers_day_of_the_week">
+                                                        <span t-field="offer.project.date_start" t-field-options='{"format": "EEEE"}'/>
+                                                    </p>
+                                                    <p class="offers_the_day">
+                                                        <strong>
+                                                            <span t-field="offer.project.date_start" t-field-options='{"format": "d"}'/>
+                                                        </strong>
+                                                    </p>
+                                                    <p class="offers_the_month">
+                                                        <span t-field="offer.project.date_start" t-field-options='{"format": "MMM"}'/>
+                                                    </p>
+                                                </div>
+                                            </div>
+                                            <div class="two">
+                                                <img class="img img-responsive shadow pictogram" src="http://bestja.d3.laboratorium.ee/ucw/img/offers_pictograms/grid-ico1-offers-list.svg"/>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-sm-3 col-md-2 hidden-xs">
+                                    <div class="tile second">
+                                        <div class="tile-content">
+                                            <div class="two">
+                                                <img t-if="not offer.organization_image" class="img img-responsive"
+                                                 src="http://lorempixel.com/g/300/300"/>
+                                                <img t-if="offer.organization_image" class="img img-responsive"
+                                                 t-attf-src="/website/image/offer/{{ offer.id }}/organization_image/300x300" alt="" />
+                                            </div>
+                                            <div class="three">
+                                                <div class="well text-center date_of_the_offer">
+                                                    <p class="offers_day_of_the_week">
+                                                        <span t-field="offer.project.date_start" t-field-options='{"format": "EEEE"}'/>
+                                                    </p>
+                                                    <p class="offers_the_day">
+                                                        <strong>
+                                                            <span t-field="offer.project.date_start" t-field-options='{"format": "d"}'/>
+                                                        </strong>
+                                                    </p>
+                                                    <p class="offers_the_month">
+                                                        <span t-field="offer.project.date_start" t-field-options='{"format": "MMM"}'/>
+                                                    </p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-xs-12 col-sm-9 col-md-8">
+                                    <div class="well well-lg content_of_the_offer">
+                                        <h2 class="title_of_the_offer" >
+                                            <a t-attf-href="{{ offer.get_public_url() }}">
+                                                <t t-esc="offer.display_name"/>
+                                            </a>
+                                        </h2>
+                                        <h2 class="organization_name">
+                                            <small>
+                                                <t t-esc="offer.project.organization.name"/>
+                                            </small>
+                                        </h2>
+                                        <div class="offer_where">
+                                            <p class="offer_place">
+                                                <t t-esc="offer.city"/>
+                                            </p>
+                                            <p class="offer_how_long" t-if="offer.hours">
+                                                <t t-esc="offer.hours"/> h
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </section>
+                    </t>
+                </div>
             </t>
         </template>
     </data>

--- a/addons/bestja_page_fixtures_fpbz/templates/pages/about_us.xml
+++ b/addons/bestja_page_fixtures_fpbz/templates/pages/about_us.xml
@@ -35,8 +35,6 @@
         <record id="about_us_menu" model="website.menu">
             <field name="name">O nas</field>
             <field name="url">/page/about_us</field>
-            <field name="parent_id" ref="website.main_menu"/>
-            <field name="sequence" type="int">21</field>
         </record>
     </data>
 </openerp>

--- a/addons/bestja_page_fixtures_fpbz/templates/pages/footer.xml
+++ b/addons/bestja_page_fixtures_fpbz/templates/pages/footer.xml
@@ -4,40 +4,42 @@
         <template id="new_footer" inherit_id="website.layout" name="New footer">
             <xpath expr="//footer" position="replace">
                 <footer id="footer_container">
-                    <div class="container-fluid footer_div">
-                        <div class="row clearfix">
-                            <div class="col-md-5 footer_logo_container">
-                                <a class="footer_logo" href="http://www.bankizywnosci.pl/"></a>
-                                <ul class="footer_contact">
-                                    <li class="mt8 mb8">
-                                        <a href="/page/contactus">Kontakt</a>
-                                    </li>
-                                    <li class="mt8 mb8">
-                                        <a href="/page/regulations">Regulamin</a>
-                                    </li>
-                                    <li class="mt8 mb8">
-                                        <a href="/page/privacy_policy">Polityka prywatności</a>
-                                    </li>
-                                    <li class="mt8 mb8">
-                                        <a href="/page/about_us">O nas</a>
-                                    </li>
-                                </ul>
-                            </div>
-                            <div class="col-md-2 centered text-center" />
-                            <div class="col-md-5 mt16 footer_icons_container">
-                                <ul class="col-md-12 footer_icons">
-                                    <li>
-                                        <a class="facebook" t-att-href="website.social_facebook"></a>
-                                    </li>
-                                    <li>
-                                        <a class="twitter" t-att-href="website.social_twitter"></a>
-                                    </li>
-                                    <li>
-                                        <a class="youtube" t-att-href="website.social_youtube"></a>
-                                    </li>
-                                </ul>
-                                <div class="copyrights">
-                                    <a href="http://www.wolontariat.bankizywnosci.pl/">© 2015,<span t-field="res_company.name"/></a>
+                    <div class="footer_div">
+                        <div class="container">
+                            <div class="row clearfix">
+                                <div class="col-md-5 footer_logo_container">
+                                    <a class="footer_logo" href="http://www.bankizywnosci.pl/"></a>
+                                    <ul class="footer_contact">
+                                        <li class="mt8 mb8">
+                                            <a href="/page/contactus">Kontakt</a>
+                                        </li>
+                                        <li class="mt8 mb8">
+                                            <a href="/page/regulations">Regulamin</a>
+                                        </li>
+                                        <li class="mt8 mb8">
+                                            <a href="/page/privacy_policy">Polityka prywatności</a>
+                                        </li>
+                                        <li class="mt8 mb8">
+                                            <a href="/page/about_us">O nas</a>
+                                        </li>
+                                    </ul>
+                                </div>
+                                <div class="col-md-2 centered text-center" />
+                                <div class="col-md-5 mt16 footer_icons_container">
+                                    <ul class="col-md-12 footer_icons">
+                                        <li>
+                                            <a class="facebook" t-att-href="website.social_facebook"></a>
+                                        </li>
+                                        <li>
+                                            <a class="twitter" t-att-href="website.social_twitter"></a>
+                                        </li>
+                                        <li>
+                                            <a class="youtube" t-att-href="website.social_youtube"></a>
+                                        </li>
+                                    </ul>
+                                    <div class="copyrights">
+                                        <a href="http://www.wolontariat.bankizywnosci.pl/">© 2015,<span t-field="res_company.name"/></a>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/addons/bestja_page_fixtures_fpbz/templates/pages/home_page.xml
+++ b/addons/bestja_page_fixtures_fpbz/templates/pages/home_page.xml
@@ -115,12 +115,13 @@
                                         <div>
                                             <p>Twoja organizacja chciałaby z nami współpracować?</p>
                                             <p>
-                                                <a>
+                                                <a href="/page/become_partner">
                                                     <strong>Dowiedz się więcej</strong>
-                                                </a> lub
-                                                <a>
-                                                    <strong>zostań organizacją partnerską</strong>
                                                 </a>
+                                                <t t-if="website.user_id == user_id">lub
+                                                <a href="/web/signup">
+                                                    <strong>zostań organizacją partnerską</strong>
+                                                </a></t>
                                             </p>
                                         </div>
                                     </div>


### PR DESCRIPTION
Changed template for list of offers by organization.
Changed script and css for sliders, they are displaying
properly on narrower viewports.
Site about us removed from menu fpbz.
Css of UCW footer changed.
In the offers list changed source of organization image,
there is no longer a placeholder, but image from organization profile.
Added printer icon on hover.
Changed links colors not only for offers sites.
Other minor changes.